### PR TITLE
bug fix (update cover.sty)

### DIFF
--- a/assets/cover.sty
+++ b/assets/cover.sty
@@ -1,7 +1,7 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{assets/cover}[2015/05/20 Cover Page]
 
-%% Require title, author, studentid, advisor, college, department. 
+%% Require title, author, studentid, advisor, college, department.
 
 \newcommand*{\makecover}{
   \begin{titlepage}
@@ -23,7 +23,7 @@
     \centerline{\heiti\zihao{1}{\@title}}
 
 
-    \vspace{75mm}
+    \vspace{50mm}
     \begin{center}
       \zihao{3}{\bf{\heiti 学生姓名}}\uline{\makebox[30mm]{\songti{\@author}}}\zihao{3}{\bf{\heiti 学号}}\uline{\makebox[50mm]{\@studentid}}\par
       \zihao{3}{\bf{\heiti 指导教师}}\uline{\makebox[92mm]{\songti{\@advisor}}}\par


### PR DESCRIPTION
减少了封面中"论文标题"与"学生姓名"之间的间距(75mm->50mm)，修复了封面下方"中国海洋大学"会被挤到第二页的bug